### PR TITLE
숨바꼭질2-박연수

### DIFF
--- a/src/january/second/숨바꼭질2/Yeonsoo.py
+++ b/src/january/second/숨바꼭질2/Yeonsoo.py
@@ -1,0 +1,41 @@
+from collections import deque
+
+n,k=map(int,input().split())
+
+q=deque()
+q.append(n)
+# 메모리 초과 방지하기 위해 그 곳에 가기까지의 최소비용을 저장하는 배열을 만든다.
+visited=[0]*100001
+visited[n]=0
+
+def go(number,position):
+    if number==0:
+        return position+1
+    elif number==1:
+        return position-1
+    else:
+        return position*2
+
+def bfs():
+    global min_time,cnt
+    while q:
+        x=q.popleft()  
+        time=visited[x]
+        if x==k:
+            min_time=time
+            cnt+=1
+            continue                            
+        for i in range(3):
+            new_x=go(i,x)
+            if new_x<0 or new_x>=100001:
+                continue
+            #방문한적 없거나,현재시간+1보다 큰 경우
+            if visited[new_x]==0 or visited[new_x]==visited[x]+1:
+                visited[new_x]=time+1
+                q.append(new_x)
+
+min_time=1e9
+cnt=0
+bfs()
+print(min_time)
+print(cnt)


### PR DESCRIPTION
## 이슈번호
- #20 

## 풀이 시간
- 1시간 반

## 접근(풀이) 방법
1. 숫자가 크기때문에 n^2으로 접근해서 시간초과가 발생했다.
2.  최단거리를 구하기 위해서 bfs으로 접근했다. 방문 조건 없이 bfs로 풀었더니 메모리초과가 났다. 중복 탐색으로 큐에 값을 넣어줬기 때문이다.

3. 메모리 초과를 해결하기 위해서 방문 배열을 초기화 해주고 방문 여부와 배열에 저장된 시간이 현재 시간+1인지 확인해서 큐와 방문배열에 현재 시간+1로 값을 넣어 줬다. 그렇게 하면 최소 시간으로 방문배열에 저장된다.
* 현재시간 +1인 경우를 확인 하는 이유는 같은 시간 레벨인지 확인해서 맞다면 큐에 넣고 탐색을 해야하기 때문이다.

## 시간복잡도
- O(NM)..?

## 질문사항
- 시간 복잡도를 잘 모르겠다
